### PR TITLE
Removed ng-annotate and updated Babel to support stage1.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-starter-es6-webpack",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "An Application Shell for generating Angular Applications with Webpack and ES6",
   "main": "app.js",
   "scripts": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,7 +41,7 @@ var config = {
       loader: 'jscs-loader'
     }],
     loaders: [
-      {test: /\.js$/, exclude: /(node_modules)/, loader: 'ng-annotate!babel'},
+      {test: /\.js$/, exclude: /(node_modules)/, loader: 'babel',  query: {stage: 1} },
       {test: /\.html/, exclude: /(node_modules)/, loader: 'html-loader'},
       {test: /\.s?css$/, loader: 'style!css!sass?includePaths[]=' + bourbon },
       {test: /\.(png|jpg)$/, loader: 'url-loader?mimetype=image/png'}


### PR DESCRIPTION
This allows for static $inject parameters to be passed in the Angular Controllers. This conforms to a more Babel like syntax.
